### PR TITLE
Do not enable extra PoP saws by default

### DIFF
--- a/ItemChanger/Modules/ReversePathOfPainSaw.cs
+++ b/ItemChanger/Modules/ReversePathOfPainSaw.cs
@@ -5,7 +5,6 @@ namespace ItemChanger.Modules
     /// <summary>
     /// Module which adds saws to the first room of Path of Pain to allow it to be traversed in reverse.
     /// </summary>
-    [DefaultModule]
     public class ReversePathOfPainSaw : Module
     {
         public override void Initialize()


### PR DESCRIPTION
Rando will turn them back on for room rando.