### PR TITLE
Update readme with link to pages docs, add workflow to rebuild docs on release

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,44 @@
+name: Docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  generate-docs:
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Checkout doc source
+        uses: actions/checkout@v2
+        with:
+          ref: docs-source
+          path: docs
+        
+      # setup .NET
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        
+      # Install DocFX
+      - name: Setup DocFX
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install docfx
+      
+      # Build and publish docs
+      - name: DocFX build
+        working-directory: docs
+        run: docfx docfx.json
+        continue-on-error: false
+
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_site
+          force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# docs branch, allows local docs testing
+/docs

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,6 @@
 
 This is a Hollow Knight mod intended to be used by other mods for the purpose of changing or adding items, locations, transitions, starts, and other aspects of the world.
 
-Documentation for most essential classes can be found within the source code at https://github.com/homothetyhk/HollowKnight.ItemChanger
+Documentation for most essential classes can be found here: https://homothetyhk.github.io/HollowKnight.ItemChanger/api/ItemChanger.html
 
 ItemChanger is licensed under LGPL.


### PR DESCRIPTION
Bit overdue on my part - due to quirks of gh actions changes on the master branch will not trigger workflows on the docs-source branch so it needs to be defined here as well. Good news is, we can have different triggers.

I've set this up to rebuild docs either on-demand or when a release is published. If you wanted you could replace L4-5 with
```
  push:
    branches: [ master, docs-source ]
```
similar to on the docs-source branch. This would automatically rebuild docs every commit which could be desirable but in theory may make the docs a bit unstable and ahead of the released library. Your call how much you care :)