### PR TITLE
Add Lemm Shop and QoL Override Tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,4 @@ healthchecksdb
 
 # docs branch, allows local docs testing
 /docs
+/ItemChanger/LocalOverrides.targets

--- a/ItemChanger/Enums.cs
+++ b/ItemChanger/Enums.cs
@@ -261,6 +261,7 @@
         SlyKeyElegantKey = 32768,
         LegEaterRepair = 65536,
         SalubraBlessing = 131072,
+        LemmRelics = 262144,
     }
 
     /// <summary>

--- a/ItemChanger/ItemChanger.csproj
+++ b/ItemChanger/ItemChanger.csproj
@@ -12,7 +12,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>true</ImplicitUsings>
     <NoWarn>1701;1702;CS1591;IDE0018</NoWarn>
+    <HollowKnightRefs>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</HollowKnightRefs>
   </PropertyGroup>
+
+  <Import Project="LocalOverrides.targets" Condition="Exists('LocalOverrides.targets')" />
+    
   <ItemGroup>
     <Using Remove="System.Net.Http" />
     <Using Remove="System.Threading" />
@@ -37,65 +41,65 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\MMHOOK_Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_PlayMaker">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\MMHOOK_PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MMHOOK_PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mono.Cecil.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Security">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mono.Security.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Mono.Security.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.RuntimeDetour">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\MonoMod.RuntimeDetour.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MonoMod.RuntimeDetour.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.Utils">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\MonoMod.Utils.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PlayMaker">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.JSONSerializeModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.JSONSerializeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.Physics2DModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.UIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Target Name="CopyMod" AfterTargets="PostBuildEvent">
-    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml;$(SolutionDir)README.md" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\$(TargetName)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml;$(SolutionDir)README.md" DestinationFolder="$(HollowKnightRefs)\Mods\$(TargetName)" SkipUnchangedFiles="true" />
   </Target>
   <Target Name="ClearReferenceCopyLocalPaths" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>

--- a/ItemChanger/ItemChanger.csproj
+++ b/ItemChanger/ItemChanger.csproj
@@ -13,6 +13,7 @@
     <ImplicitUsings>true</ImplicitUsings>
     <NoWarn>1701;1702;CS1591;IDE0018</NoWarn>
     <HollowKnightRefs>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</HollowKnightRefs>
+    <ModTargetName>$(TargetName)</ModTargetName>
   </PropertyGroup>
 
   <Import Project="LocalOverrides.targets" Condition="Exists('LocalOverrides.targets')" />
@@ -99,7 +100,7 @@
     </Reference>
   </ItemGroup>
   <Target Name="CopyMod" AfterTargets="PostBuildEvent">
-    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml;$(SolutionDir)README.md" DestinationFolder="$(HollowKnightRefs)\Mods\$(TargetName)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath);$(TargetDir)$(TargetName).pdb;$(TargetDir)$(TargetName).xml;$(SolutionDir)README.md" DestinationFolder="$(HollowKnightRefs)\Mods\$(ModTargetName)" SkipUnchangedFiles="true" />
   </Target>
   <Target Name="ClearReferenceCopyLocalPaths" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>

--- a/ItemChanger/LocationNames.cs
+++ b/ItemChanger/LocationNames.cs
@@ -18,6 +18,7 @@ namespace ItemChanger
         public const string Iselda = "Iselda";
         public const string Salubra = "Salubra";
         public const string Leg_Eater = "Leg_Eater";
+        public const string Lemm = "Lemm";
         public const string Grubfather = "Grubfather";
         public const string Seer = "Seer";
         public const string Lurien = "Lurien";

--- a/ItemChanger/Locations/ShopLocation.cs
+++ b/ItemChanger/Locations/ShopLocation.cs
@@ -286,7 +286,12 @@ namespace ItemChanger.Locations
             Lambda addIntToConfirm = new Lambda(AddIntToConfirm);
 
             init.AddLastAction(resetSprites);
-            getDetailsInit.SetActions(setName, setSprite);
+            getDetailsInit.SetActions(
+                setName, 
+                setSprite,
+                // 7-8 Activate detail pane
+                getDetailsInit.Actions[7],
+                getDetailsInit.Actions[8]);
             getDetails.SetActions(setName);
             charmsRequiredInit.SetActions(setDesc);
             charmsRequired.SetActions(setDesc);

--- a/ItemChanger/Locations/SpecialLocations/KingsBrandLocation.cs
+++ b/ItemChanger/Locations/SpecialLocations/KingsBrandLocation.cs
@@ -29,16 +29,6 @@ namespace ItemChanger.Locations.SpecialLocations
             base.OnUnload();
             Events.RemoveFsmEdit(sceneName, new("Avalanche", "Activate"), Destroy);
             Events.RemoveFsmEdit(sceneName, new("Avalanche End", "Control"), Destroy);
-            try
-            {
-                Type.GetType("QoL.SettingsOverride, QoL")
-                    ?.GetMethod("RemoveSettingOverride", BindingFlags.Public | BindingFlags.Static)
-                    ?.Invoke(null, new object[] { "SkipCutscenes", "AfterKingsBrandGet" });
-            }
-            catch (Exception e)
-            {
-                LogError(e);
-            }
         }
 
         private void Destroy(PlayMakerFSM fsm) => UnityEngine.Object.Destroy(fsm.gameObject);

--- a/ItemChanger/Locations/SpecialLocations/KingsBrandLocation.cs
+++ b/ItemChanger/Locations/SpecialLocations/KingsBrandLocation.cs
@@ -12,16 +12,6 @@ namespace ItemChanger.Locations.SpecialLocations
             base.OnLoad();
             Events.AddFsmEdit(sceneName, new("Avalanche", "Activate"), Destroy);
             Events.AddFsmEdit(sceneName, new("Avalanche End", "Control"), Destroy);
-            try
-            {
-                Type.GetType("QoL.SettingsOverride, QoL")
-                    ?.GetMethod("OverrideSettingToggle", BindingFlags.Public | BindingFlags.Static)
-                    ?.Invoke(null, new object[] { "SkipCutscenes", "AfterKingsBrandGet", false });
-            }
-            catch (Exception e)
-            {
-                LogError(e);
-            }
         }
 
         protected override void OnUnload()

--- a/ItemChanger/Resources/locations.json
+++ b/ItemChanger/Resources/locations.json
@@ -67,6 +67,25 @@
     "flingType": "DirectDeposit",
     "tags": null
   },
+  "Lemm": {
+    "$type": "ItemChanger.Locations.ShopLocation, ItemChanger",
+    "objectName": "Relic Dealer",
+    "fsmName": "Conversation Control",
+    "defaultShopItems": "None",
+    "requiredPlayerDataBool": "",
+    "dungDiscount": false,
+    "name": "Lemm",
+    "sceneName": "Ruins1_05b",
+    "flingType": "DirectDeposit",
+    "tags": [
+      {
+        "$type": "ItemChanger.Tags.QolOverrideTag, ItemChanger",
+        "ModuleName": "NPCSellAll",
+        "SettingName": "LemmSellAll",
+        "Enable": false
+      }
+    ]
+  },
   "Grubfather": {
     "$type": "ItemChanger.Locations.SpecialLocations.CostChestLocation, ItemChanger",
     "chestLocation": {
@@ -1067,7 +1086,14 @@
     "name": "King's_Brand",
     "sceneName": "Room_Wyrm",
     "flingType": "Everywhere",
-    "tags": null
+    "tags": [
+      {
+        "$type": "ItemChanger.Tags.QolOverrideTag, ItemChanger",
+        "ModuleName": "SkipCutscenes",
+        "SettingName": "AfterKingsBrandGet",
+        "Enable": false
+      }
+    ]
   },
   "Godtuner": {
     "$type": "ItemChanger.Locations.SpecialLocations.GodtunerLocation, ItemChanger",

--- a/ItemChanger/Tags/QolOverrideTag.cs
+++ b/ItemChanger/Tags/QolOverrideTag.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ItemChanger.Tags
+{
+    /// <summary>
+    /// A tag which enables a QoL override for an individual setting in a module, or an entire module.
+    /// </summary>
+    public class QolOverrideTag : Tag
+    {
+        public string ModuleName;
+        public string SettingName;
+        public bool Enable;
+
+        public override void Load(object parent)
+        {
+            base.Load(parent);
+
+            try
+            {
+                if (ModuleName != null)
+                {
+                    Type settingsOverride = Type.GetType("QoL.SettingsOverride, QoL");
+                    if (SettingName == null)
+                    {
+                        settingsOverride
+                            ?.GetMethod("OverrideModuleToggle", BindingFlags.Public | BindingFlags.Static)
+                            .Invoke(null, new object[] { ModuleName, Enable });
+                    }
+                    else
+                    {
+                        settingsOverride
+                            ?.GetMethod("OverrideSettingToggle", BindingFlags.Public | BindingFlags.Static)
+                            .Invoke(null, new object[] { ModuleName, SettingName, Enable });
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                LogError(e);
+            }
+        }
+
+        public override void Unload(object parent)
+        {
+            base.Unload(parent);
+
+            try
+            {
+                if (ModuleName != null)
+                {
+                    Type settingsOverride = Type.GetType("QoL.SettingsOverride, QoL");
+                    if (SettingName == null)
+                    {
+                        settingsOverride
+                            ?.GetMethod("RemoveModuleOverride", BindingFlags.Public | BindingFlags.Static)
+                            ?.Invoke(null, new object[] { ModuleName });
+                    }
+                    else
+                    {
+                        settingsOverride
+                            ?.GetMethod("RemoveSettingOverride", BindingFlags.Public | BindingFlags.Static)
+                            ?.Invoke(null, new object[] { ModuleName, SettingName });
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                LogError(e);
+            }
+        }
+    }
+}

--- a/ItemChanger/Util/ShopUtil.cs
+++ b/ItemChanger/Util/ShopUtil.cs
@@ -1,6 +1,6 @@
-﻿using System.Reflection;
+﻿using ItemChanger.Components;
+using System.Reflection;
 using TMPro;
-using ItemChanger.Components;
 
 namespace ItemChanger.Util
 {
@@ -216,6 +216,11 @@ namespace ItemChanger.Util
                     2 => DefaultShopItems.LegEaterCharms,
                     12 or 13 or 14 => DefaultShopItems.LegEaterRepair,
                     _ => null,
+                },
+                SceneNames.Ruins1_05b => stats.specialType switch
+                {
+                    4 or 5 or 6 or 7 => DefaultShopItems.LemmRelics,
+                    _ => null
                 },
                 _ => null,
             };


### PR DESCRIPTION
Adds handling for Lemm's shop to ShopLocation. All of the changes to accomodate Lemm can be applied to other shops unconditionally because the FSMs are the same.

~~Before merging I'd like to implement relic costs as well (probably need to be cumulative for rando logic to ever work, though ideally I would like them not to be). In the meanwhile~~ feel free to complain about the core changes :)
