### PR TITLE
Fix possible NRE

### DIFF
--- a/ItemChanger/StartDef.cs
+++ b/ItemChanger/StartDef.cs
@@ -164,7 +164,7 @@ namespace ItemChanger
                 {
                     // HC.Respawn
                     self.IgnoreInput();
-                    RespawnMarker rm = GetSpawnPoint().GetComponent<RespawnMarker>();
+                    RespawnMarker rm = GetSpawnPoint()?.GetComponent<RespawnMarker>();
                     if (rm && !rm.respawnFacingRight) self.FaceLeft();
                     else self.FaceRight();
                     (typeof(HeroController).GetField("heroInPosition", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(self) as HeroController.HeroInPosition)?.Invoke(false);


### PR DESCRIPTION
See modlog and surrounding discussion for context: https://discord.com/channels/772964112908156938/929944151800299540/1401363646805835908

I couldn't reproduce this locally but the stack trace and error report are pretty clear; I think this one-line change will at least help root-cause this issue further if not fix it entirely.  Based on the implementation of HeroController.LocateSpawnPoint(), it's not unreasonable for the 'spawnPoint' variable in the state machine to wind up null.